### PR TITLE
Fix hooks make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ clean:
 	rm -rf Projects/*/*.xcodeproj
 
 hooks:
-	$(shell ./Scripts/Git/Hooks/install.sh)
+	./Scripts/Git/Hooks/install.sh
 
 test:
 ifeq ($(TRAVIS_BRANCH), "MASTER")


### PR DESCRIPTION
As it was, calling `make hooks` yielded a weird error on my side. Calling script directly instead of `$(shell ...)` format works.